### PR TITLE
Cleanup older rubies, add javascript ansible

### DIFF
--- a/ansible/all.yml
+++ b/ansible/all.yml
@@ -3,3 +3,4 @@
 - import_playbook: postgres.yml
 - import_playbook: ruby.yml
 - import_playbook: java.yml
+- import_playbook: javascript.yml

--- a/ansible/javascript.yml
+++ b/ansible/javascript.yml
@@ -1,0 +1,15 @@
+- hosts: all
+
+  tasks:
+    - import_tasks: sudo.yml
+
+    - name: Install node
+      homebrew: name=node
+
+    - name: Install Webstorm
+      homebrew_cask: name=webstorm
+
+    - name: Install Pivotal IDE prefs
+      command: ./bin/ide_prefs --ide=webstorm install
+      args:
+        chdir: ~/workspace/pivotal_ide_prefs/cli

--- a/ansible/ruby.yml
+++ b/ansible/ruby.yml
@@ -6,7 +6,7 @@
     PATH: "/usr/local/bin:/Users/{{ ansible_env.USER }}/.rbenv/shims:{{ ansible_env.PATH }}"
 
   vars:
-    current_version: 2.3.1
+    current_version: 2.7.1
 
   tasks:
 
@@ -18,7 +18,6 @@
       args:
         creates: ~/.rbenv/versions/{{ item }}
       with_items:
-        - 2.0.0-p648
         - "{{ current_version }}"
 
     - name: Use Ruby {{ current_version }}


### PR DESCRIPTION
Re-imaging machine with Catalina gave me the below error. Not sure if we need to keep installing older rubies by default. I went with newest & oldest supported versions. Also added setup for javascript.
`
Failed: [localhost] (item=2.0.0-p648) => {"ansible_loop_var": "item", "changed": true, "cmd": ["rbenv", "install", "2.0.0-p648"], "delta": "0:03:34.179096", "end": "2020-08-19 13:59:31.765047", "item": "2.0.0-p648", "msg": "non-zero return code", "rc": 1, "start": "2020-08-19 13:55:57.585951", "stderr": "Downloading openssl-1.0.2u.tar.gz...\n-> https://dqw8nmjcqpjn7.cloudfront.net/ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16\nInstalling openssl-1.0.2u...\nInstalled openssl-1.0.2u to /Users/pivotal/.rbenv/versions/2.0.0-p648\n\nDownloading ruby-2.0.0-p648.tar.bz2...\n-> https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p648.tar.bz2\nInstalling ruby-2.0.0-p648...\n\nWARNING: ruby-2.0.0-p648 is past its end of life and is now unsupported.\nIt no longer receives bug fixes or critical security updates.\n\n\nBUILD FAILED (Mac OS X 10.15.6 using ruby-build 20200727)\n\nInspect or clean up the working tree at /var/folders/ft/v1_l0jqx1fs0hf_1tnpfzc1m0000gn/T/ruby-build.20200819135557.11795.YI4uxe\nResults logged to /var/folders/ft/v1_l0jqx1fs0hf_1tnpfzc1m0000gn/T/ruby-build.20200819135557.11795.log\n\nLast 10 log lines:\n const ID mid = rb_frame_last_func();\n ^\nthread.c:4835:20: note: did you mean 'rb_frame_this_func'?\n./include/ruby/intern.h:369:4: note: 'rb_frame_this_func' declared here\nID rb_frame_this_func(void);\n ^\n1 warning and 1 error generated.\nmake: *** [thread.o] Error 1\nmake: *** Waiting for unfinished jobs....\n1 warning generated.", "stderr_lines": ["Downloading openssl-1.0.2u.tar.gz...", "-> https://dqw8nmjcqpjn7.cloudfront.net/ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16", "Installing openssl-1.0.2u...", "Installed openssl-1.0.2u to /Users/pivotal/.rbenv/versions/2.0.0-p648", "", "Downloading ruby-2.0.0-p648.tar.bz2...", "-> https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p648.tar.bz2", "Installing ruby-2.0.0-p648...", "", "WARNING: ruby-2.0.0-p648 is past its end of life and is now unsupported.", "It no longer receives bug fixes or critical security updates.", "", "", "BUILD FAILED (Mac OS X 10.15.6 using ruby-build 20200727)", "", "Inspect or clean up the working tree at /var/folders/ft/v1_l0jqx1fs0hf_1tnpfzc1m0000gn/T/ruby-build.20200819135557.11795.YI4uxe", "Results logged to /var/folders/ft/v1_l0jqx1fs0hf_1tnpfzc1m0000gn/T/ruby-build.20200819135557.11795.log", "", "Last 10 log lines:", " const ID mid = rb_frame_last_func();", " ^", "thread.c:4835:20: note: did you mean 'rb_frame_this_func'?", "./include/ruby/intern.h:369:4: note: 'rb_frame_this_func' declared here", "ID rb_frame_this_func(void);", " ^", "1 warning and 1 error generated.", "make: *** [thread.o] Error 1", "make: *** Waiting for unfinished jobs....", "1 warning generated."], "stdout": "ruby-build: using readline from homebrew", "stdout_lines": ["ruby-build: using readline from homebrew"]}
`